### PR TITLE
Understand client components

### DIFF
--- a/app/reviews/[slug]/page.tsx
+++ b/app/reviews/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import HeadingComponent from "@/components/heading-component/heading-component";
-import { getReview, getSlugs } from "@/lib/reviews";import Buttons from "@/components/buttons/buttons";
- 
+import { getReview, getSlugs } from "@/lib/reviews";
+import ShareBtn from "@/components/buttons/share-link-btn-component/share-link-btn-component";
 
 export interface ReviewPageProps {
   params: {
@@ -27,22 +27,20 @@ export default async function ReviewPage({
 }: ReviewPageProps) {
   const { title, date, image, body } = await getReview(slug);
 
-  let clicked
- const handleClick = () => {
-  navigator.clipboard.writeText(window.location.href);
-  // console.log("clicked")
-  clicked(true);
-  setTimeout(() => {
-  clicked(false) ;
-  }, 2000);
-};
+  const onClickFunction = `navigator.clipboard.writeText(window.location.href)`;
+  const helperFunction = `setTimeout(() => {
+        alert("BTN helper function");
+      }, 500)`;
 
   return (
     <div>
       <HeadingComponent text={title} />
       <div className="flex gap-3 items-baseline">
         <p className="italic pb-2 mr-4">{date}</p>
-        <Buttons />
+        <ShareBtn
+          onClickFunction={onClickFunction}
+          helperFunction={helperFunction}
+        />
       </div>
       {image ? (
         <img

--- a/app/reviews/[slug]/page.tsx
+++ b/app/reviews/[slug]/page.tsx
@@ -40,6 +40,7 @@ export default async function ReviewPage({
         <ShareBtn
           onClickFunction={onClickFunction}
           helperFunction={helperFunction}
+          setClick={true}
         />
       </div>
       {image ? (

--- a/components/buttons/buttons.tsx
+++ b/components/buttons/buttons.tsx
@@ -1,9 +1,0 @@
-import ShareBtn from "./share-link-btn-component/share-link-btn-component";
-
-export default function Buttons( ) {
-  return (
-    <div>
-      <ShareBtn   />
-    </div>
-  );
-}

--- a/components/buttons/share-link-btn-component/share-link-btn-component.tsx
+++ b/components/buttons/share-link-btn-component/share-link-btn-component.tsx
@@ -6,9 +6,10 @@ import { LinkIcon } from "@heroicons/react/20/solid";
 export interface ShareBtnProps {
   onClickFunction?: string;
   helperFunction?: string;
+  setClick?: boolean;
 }
 
-export default function ShareBtn({ onClickFunction, helperFunction }: ShareBtnProps) {
+export default function ShareBtn({ onClickFunction, helperFunction, setClick }: ShareBtnProps) {
   const [clicked, setClicked] = useState(false);
 
   const btnFunction1: () => void = new Function(
@@ -17,10 +18,11 @@ export default function ShareBtn({ onClickFunction, helperFunction }: ShareBtnPr
   const btnFunction2: () => void = new Function(
     `${helperFunction}`
   ) as () => void;
+ 
 
   const handleClick = () => {
     onClickFunction ? btnFunction1() : null;
-    setClicked(true);
+    setClicked(setClick);
     helperFunction ? btnFunction2() : null;
     setTimeout(() => {
       setClicked(false);

--- a/components/buttons/share-link-btn-component/share-link-btn-component.tsx
+++ b/components/buttons/share-link-btn-component/share-link-btn-component.tsx
@@ -1,34 +1,46 @@
 "use client";
 import { useState } from "react";
-import { LinkIcon } from '@heroicons/react/20/solid'
+import { LinkIcon } from "@heroicons/react/20/solid";
+
 
 export interface ShareBtnProps {
-  onClick?: () => void;
+  onClickFunction?: string;
+  helperFunction?: string;
 }
 
-export default function ShareBtn({ onClick }: ShareBtnProps) {
+export default function ShareBtn({ onClickFunction, helperFunction }: ShareBtnProps) {
   const [clicked, setClicked] = useState(false);
-  console.log("rendering with hydration", clicked);
+
+  const btnFunction1: () => void = new Function(
+    `${onClickFunction}`
+  ) as () => void;
+  const btnFunction2: () => void = new Function(
+    `${helperFunction}`
+  ) as () => void;
 
   const handleClick = () => {
-    navigator.clipboard.writeText(window.location.href);
-    // console.log("clicked")
+    onClickFunction ? btnFunction1() : null;
     setClicked(true);
+    helperFunction ? btnFunction2() : null;
     setTimeout(() => {
       setClicked(false);
-    }, 2000);
+    }
+    , 1000);
   };
-
+ 
   return (
     <div className="flex items-baseline">
       <button
-        onClick={handleClick}
+        onClick={() => handleClick()}
         className="flex gap-1 items-centerrounded border rounded border-slate-400 px-2  mb-3 py-2 text-slate-500 text-sm hover:shadow-xl hover:bg-orange-100"
       >
-      <LinkIcon className="h-5, w-5"/>
-      {clicked ?  <span className=" text-orange-500  ">Link copied to clipboard</span>  : "Share"}
+        <LinkIcon className="h-5, w-5" />
+        {clicked ? (
+          <span className=" text-orange-500  ">Link copied to clipboard</span>
+        ) : (
+          "Share"
+        )}
       </button>
-     
     </div>
   );
 }


### PR DESCRIPTION
you can have reusable BTN with an onClick only **if the onClick** is passed as a prop from  the parent element as a string. 

then in the reusable BTC component you can do this:
(...)`export default function ShareBtn({ onClickFunction, helperFunction }: ShareBtnProps) {
  const [clicked, setClicked] = useState(false);
`export default function ShareBtn({ onClickFunction, helperFunction, setClick }: ShareBtnProps) {
  const [clicked, setClicked] = useState(false);

  const btnFunction1: () => void = new Function(
    `${onClickFunction}`
  ) as () => void;
  const btnFunction2: () => void = new Function(
    `${helperFunction}`
  ) as () => void;
 

  const handleClick = () => {
    onClickFunction ? btnFunction1() : null;
    setClicked(setClick);
    helperFunction ? btnFunction2() : null;
    setTimeout(() => {
      setClicked(false);
    }
    , 1000);
  };
 
  return (
    <div className="flex items-baseline">
      <button
        onClick={() => handleClick()}
        className="flex gap-1 items-centerrounded border rounded border-slate-400 px-2  mb-3 py-2 text-slate-500 text-sm hover:shadow-xl hover:bg-orange-100"
      >`(...)
 
It is also possible to pass a boolean to the change BTN state, you will still need a few types of BTNs like: 
 - shareLink (in this example) 
 - "regular" with styling choices _primary_, _secondary_, etc.
 - Link styles as button (maybe?) 